### PR TITLE
Fix `flutter pub get` command

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -594,10 +594,10 @@ packages:
     description:
       path: "packages/google_maps_flutter/google_maps_flutter_ios"
       ref: main
-      resolved-ref: ca9d019de61f4e20acd3004a1a49dc9db9bb4f58
+      resolved-ref: "89d134da61ae7602820ed8386dd8abc19644d253"
       url: "https://github.com/jakobkoerber/packages.git"
     source: git
-    version: "2.4.0"
+    version: "2.4.1"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1601,7 +1601,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "1c1b397652b5806bf2e04333139bb9d3282fe630"
+      resolved-ref: ac1d33717ee9e22c8df08023b298ad53df69a1bb
       url: "https://github.com/jakobkoerber/xml2json.git"
     source: git
     version: "6.2.2"


### PR DESCRIPTION
I removed `xml2json` from the `pubspec.lock` and executed `flutter pub get`.

Fixes #204