### PR TITLE
Selectable Lecture Details

### DIFF
--- a/lib/lectureComponent/views/detailed_lecture_info_row_view.dart
+++ b/lib/lectureComponent/views/detailed_lecture_info_row_view.dart
@@ -28,7 +28,7 @@ class DetailedLectureInfoRowView extends ConsumerWidget {
                 .titleSmall
                 ?.copyWith(fontWeight: FontWeight.bold),
           ),
-          Linkify(
+          SelectableLinkify(
             text: information.replaceAll(r'\\n', "\n").replaceAll(r'\t', "\t"),
             onOpen: (link) => UrlLauncher.urlString(link.url, ref),
           ),


### PR DESCRIPTION
Making the lecture details selectable facilitates copying text, e.g. to search for recommended literature.