### PR TITLE
Fixed calendar widget bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To update the generated stubs for the Campus, you need protoc installed, then ac
 dart pub global activate protoc_plugin
 export PATH="$PATH:$HOME/.pub-cache/bin"
 curl -o protos/tumdev/campus_backend.proto https://raw.githubusercontent.com/TUM-Dev/Campus-Backend/main/server/api/tumdev/campus_backend.proto
-protoc --dart_out=grpc:lib/base/networking/apis -I./protos google/protobuf/timestamp.proto google/protobuf/empty.proto protos/tumdev/campus_backend.proto 
+protoc --dart_out=grpc:lib/base/networking/apis -I./protos google/protobuf/timestamp.proto google/protobuf/empty.proto tumdev/campus_backend.proto 
 ```
 
 ### Current needed Forks

--- a/android/app/src/main/kotlin/de/tum/in/tumcampus/util/DateTimeUtils.kt
+++ b/android/app/src/main/kotlin/de/tum/in/tumcampus/util/DateTimeUtils.kt
@@ -27,11 +27,20 @@ fun LocalDateTime.timeAgo(context: Context): String {
     val minutes = duration.toMinutes()
 
     return when {
-        years > 0 -> context.resources.getQuantityString(R.plurals.yearsAgo, years.toInt())
-        months > 0 -> context.resources.getQuantityString(R.plurals.monthsAgo, months.toInt())
-        days > 0 -> context.resources.getQuantityString(R.plurals.daysAgo, days.toInt())
-        hours > 0 -> context.resources.getQuantityString(R.plurals.hoursAgo, hours.toInt())
-        minutes > 0 -> context.resources.getQuantityString(R.plurals.minutesAgo, minutes.toInt())
+        years > 0 -> formattedTimeAgo(context, R.plurals.yearsAgo, years.toInt())
+        months > 0 -> formattedTimeAgo(context, R.plurals.monthsAgo, months.toInt())
+        days > 0 -> formattedTimeAgo(context, R.plurals.daysAgo, days.toInt())
+        hours > 0 -> formattedTimeAgo(context, R.plurals.hoursAgo, hours.toInt())
+        minutes > 0 -> formattedTimeAgo(context, R.plurals.minutesAgo, minutes.toInt())
         else -> context.resources.getString(R.string.just_now)
+    }
+}
+
+fun formattedTimeAgo(context: Context, id: Int, number: Int): String {
+    val quantityString = context.resources.getQuantityString(id, number)
+    return if (quantityString.contains("%d", ignoreCase = false)) {
+        String.format(quantityString, number)
+    } else {
+        quantityString
     }
 }


### PR DESCRIPTION
There was a bug in the calendar widget
<img width="198" alt="Before" src="https://github.com/user-attachments/assets/ede9ec4b-cef7-400f-9d5b-6e38a64d70c3">

The code solves this by checking whether the String contains %d and then inserts the correct number.
<img width="190" alt="After" src="https://github.com/user-attachments/assets/4e9e6b68-f306-4696-ba68-7461ce7741ec">

Also, there was a small issue with the setup instructions in the readme